### PR TITLE
Fix broken codegen with fields with same type

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,8 @@ const generateQuery = (
       ).queryStr)
       .filter(cur => cur)
       .join('\n');
+    // Allow the same references in siblings 
+    crossReferenceKeyList.pop();
   }
 
   if (!(curType.getFields && !childQuery)) {


### PR DESCRIPTION
Pop the crossReferenceKeyList after recursing down so that codegen succeeds when two siblings have the same complex type.