### PR TITLE
Feature Exclude Deprecated Fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # output files of test
 example/output
 example/output2
+example/output3
+example/output4
 
 # Logs
 logs

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ mutation signup($username: String!, email: String!, password: String!){
 
 ```
 
+The tool will automatically exclude any `@deprecated` schema fields (see more on schema directives [here](https://www.apollographql.com/docs/graphql-tools/schema-directives)). To change this behavior to include deprecated fields you can use the `includeDeprecatedFields` flag when running the tool, e.g. `gqlg --includeDeprecatedFields`.
+
 ## Usage example
 
 Say you have a graphql schema like this: 

--- a/example/sampleTypeDef.graphql
+++ b/example/sampleTypeDef.graphql
@@ -1,5 +1,6 @@
 type Query {
     user(id: Int!): User!
+    members: [Member!] @deprecated(reason: "Test a deprecated query")
 }
 
 type Mutation {
@@ -17,6 +18,10 @@ type Mutation {
     setConfig(
         prefs: PrefsInput
     ): Config!
+
+    sendMessage(
+        message: String!
+    ): String! @deprecated(reason: "Test a deprecated mutation")
 }
 
 input PrefsInput {
@@ -46,6 +51,7 @@ type User {
     createdAt: String!
     context: Context!
     details: UserDetails!
+    address: String! @deprecated(reason: "Test a deprecated field")
 }
 
 union UserDetails = Guest | Member

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ program
   .option('--schemaFilePath [value]', 'path of your graphql schema file')
   .option('--destDirPath [value]', 'dir you want to store the generated queries')
   .option('--depthLimit [value]', 'query depth you want to limit(The default is 100)')
-  .option('--includeDeprecatedFields [value]', 'Flag to include deprecated fields (The default is to exclude)')
+  .option('-C, --includeDeprecatedFields [value]', 'Flag to include deprecated fields (The default is to exclude)')
   .parse(process.argv);
 
 const { schemaFilePath, destDirPath, depthLimit = 100, includeDeprecatedFields = false } = program;

--- a/test/index.js
+++ b/test/index.js
@@ -7,8 +7,63 @@ test('validate generated queries', async () => {
   queries.mutations.signin.indexOf('signin').should.not.equal(-1);
 });
 
-test('limt depth', async () => {
+test('limit depth', async () => {
   cp.execSync('node index.js --schemaFilePath ./example/sampleTypeDef.graphql --destDirPath ./example/output2 --depthLimit 1');
   const queries = require('../example/output2');
   queries.mutations.signup.indexOf('createdAt').should.equal(-1);
+});
+
+test('excludes deprecated fields by default', async () => {
+  cp.execSync('node index.js --schemaFilePath ./example/sampleTypeDef.graphql --destDirPath ./example/output3 --depthLimit 1');
+  const queries = require('../example/output3');
+  should(typeof queries.queries.user).be.exactly("string");
+  should(queries.queries.members === undefined).be.true();
+  should(queries.mutations.sendMessage === undefined).be.true();
+
+  const expected = `query user($language: String, $id: Int!){
+    user(id: $id){
+        id
+        username
+        email
+        createdAt
+        details{
+            ... on Guest {
+                region(language: $language)
+            }
+            ... on Member {
+                address
+            }
+        }
+    }
+}`
+
+  should(queries.queries.user === expected).be.true();  
+});
+
+test('includes deprecated fields with includeDeprecatedFields flag', async () => {
+  cp.execSync('node index.js --schemaFilePath ./example/sampleTypeDef.graphql --destDirPath ./example/output4 --depthLimit 1 --includeDeprecatedFields');
+  const queries = require('../example/output4');
+
+  should(typeof queries.queries.user).be.exactly("string");
+  should(typeof queries.queries.members).be.exactly("string");
+  should(typeof queries.mutations.sendMessage).be.exactly("string");
+
+  const expected = `query user($language: String, $id: Int!){
+    user(id: $id){
+        id
+        username
+        email
+        createdAt
+        details{
+            ... on Guest {
+                region(language: $language)
+            }
+            ... on Member {
+                address
+            }
+        }
+        address
+    }
+}`
+  should(queries.queries.user === expected).be.true();
 });


### PR DESCRIPTION
**This PR:**

* Address #16 and provide default behavior to exclude `@deprecated` fields from gql-generator output and an optional command line argument to include `@deprecated` fields if the user wants to opt out of this behavior.

**Notes:**

* I think I found the right places to add filters on the `isDeprecated` flag. If not I'm happy to adjust the code!